### PR TITLE
UseIndex fix

### DIFF
--- a/ads-in.js
+++ b/ads-in.js
@@ -90,11 +90,11 @@ module.exports = function (RED) {
         if (cfg.useIndex) {
           delete(cfg.symname)
           cfg.indexGroup = parseInt(cfg.indexGroup.toString())
-          if (isNaA(cfg.indexGroup)) {
+          if (isNaN(cfg.indexGroup)) {
             cfg.indexGroup = 0
           }
           cfg.indexOffset = parseInt(cfg.indexOffset.toString())
-          if (isNaA(cfg.indexOffset)) {
+          if (isNaN(cfg.indexOffset)) {
             cfg.indexOffset = 0
           }
         } else {

--- a/ads-notification.js
+++ b/ads-notification.js
@@ -28,11 +28,11 @@ module.exports = function (RED) {
       if (node.useIndex) {
         delete(node.symname)
         node.indexGroup = parseInt(node.indexGroup.toString())
-        if (isNaA(node.indexGroup)) {
+        if (isNaN(node.indexGroup)) {
           node.indexGroup = 0
         }
         node.indexOffset = parseInt(node.indexOffset.toString())
-        if (isNaA(node.indexOffset)) {
+        if (isNaN(node.indexOffset)) {
           node.indexOffset = 0
         }
       } else {


### PR DESCRIPTION
The name of the function isNaN was written isNaA and this was making the entire "useIndex" functionality useless for the ADS-in and ADS-notification  nodes.